### PR TITLE
Clean up the alma9 images, use automount with the image that has cvmfs

### DIFF
--- a/Docker/alma9/alma9-build/Dockerfile
+++ b/Docker/alma9/alma9-build/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf update -y && \
     dnf install -y ccache mold && \
     dnf remove -y NetworkManager llvm-libs xorg-x11-fonts-ISO8859-1-100dpi dejavu-sans-fonts selinux-policy && \
     # We don't need valgrind but mesa-libGL-devel depends on it
-    rpm -e --nodeps valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam && \
+    rpm -e --nodeps --quiet valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam || true && \
     dnf clean all
 
 CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-build/Dockerfile
+++ b/Docker/alma9/alma9-build/Dockerfile
@@ -18,6 +18,9 @@ RUN dnf update -y && \
     dnf remove -y NetworkManager llvm-libs xorg-x11-fonts-ISO8859-1-100dpi dejavu-sans-fonts selinux-policy && \
     # We don't need valgrind but mesa-libGL-devel depends on it
     rpm -e --nodeps valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam || true && \
+    for pkg in valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam; do \
+        rpm -e --nodeps "$pkg" || true \
+    done && \
     dnf clean all
 
 CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-build/Dockerfile
+++ b/Docker/alma9/alma9-build/Dockerfile
@@ -17,9 +17,8 @@ RUN dnf update -y && \
     dnf install -y ccache mold && \
     dnf remove -y NetworkManager llvm-libs xorg-x11-fonts-ISO8859-1-100dpi dejavu-sans-fonts selinux-policy && \
     # We don't need valgrind but mesa-libGL-devel depends on it
-    rpm -e --nodeps valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam || true && \
     for pkg in valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam; do \
-        rpm -e --nodeps "$pkg" || true \
+        rpm -e --nodeps "$pkg" || true; \
     done && \
     dnf clean all
 

--- a/Docker/alma9/alma9-build/Dockerfile
+++ b/Docker/alma9/alma9-build/Dockerfile
@@ -3,11 +3,21 @@ FROM gitlab-registry.cern.ch/linuxsupport/alma9-base
 # epel-release and parallel needed for the validation
 # wget needed for some tests
 RUN dnf update -y && \
-    dnf groupinstall -y "Development Tools" && \
-    dnf install -y vim gfortran wget python3-pip epel-release mesa-libGL mesa-libGL-devel mesa-libGLU mesa-libGLU-devel krb5-devel && \
-    dnf install -y parallel ccache mold && \
+    # dnf groupinstall -y "Development Tools" && \
+    dnf install -y \
+                   # Needed for compiling
+                   glibc-headers glibc-devel \
+                   # Requirements
+                   mesa-libGL mesa-libGL-devel mesa-libGLU mesa-libGLU-devel krb5-devel \
+                   # Tools
+                   git patch vim wget epel-release \
+                   # For fetching commits of packages
+                   python3-requests python3-yaml && \
+    # For building and CI
+    dnf install -y ccache mold && \
+    dnf remove -y NetworkManager llvm-libs xorg-x11-fonts-ISO8859-1-100dpi dejavu-sans-fonts selinux-policy && \
+    # We don't need valgrind but mesa-libGL-devel depends on it
+    rpm -e --nodeps valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam && \
     dnf clean all
-
-RUN pip install boto3 requests
 
 CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-build/Dockerfile
+++ b/Docker/alma9/alma9-build/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf update -y && \
     dnf install -y ccache mold && \
     dnf remove -y NetworkManager llvm-libs xorg-x11-fonts-ISO8859-1-100dpi dejavu-sans-fonts selinux-policy && \
     # We don't need valgrind but mesa-libGL-devel depends on it
-    rpm -e --nodeps --quiet valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam || true && \
+    rpm -e --nodeps valgrind valgrind-devel gl-manpages git-core-doc grub2-common grub2-efi-x64 grub2-tools-minimal emacs-filesystem systemd systemd-udev systemd-libs systemd-pam || true && \
     dnf clean all
 
 CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-cvmfs/Dockerfile
+++ b/Docker/alma9/alma9-cvmfs/Dockerfile
@@ -10,6 +10,7 @@ RUN dnf install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-
     dnf clean all
 
 COPY mount.sh /mount.sh
+RUN chmod +x /mount.sh
 
-ENTRYPOINT ["/bin/sh", "-c", "/mount.sh"]
+ENTRYPOINT ["/mount.sh"]
 CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-cvmfs/Dockerfile
+++ b/Docker/alma9/alma9-cvmfs/Dockerfile
@@ -2,13 +2,14 @@ FROM alma9
 
 RUN dnf install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && \
     dnf install -y cvmfs && \
-    mkdir /cvmfs/cvmfs-config.cern.ch /cvmfs/sw.hsf.org /cvmfs/sw-nightlies.hsf.org && \
     echo "CVMFS_CONFIG_REPOSITORY=cvmfs-config.cern.ch" > /etc/cvmfs/default.local && \
     echo "CVMFS_CLIENT_PROFILE=single" >> /etc/cvmfs/default.local && \
     echo "CVMFS_QUOTA_LIMIT='15000'" >> /etc/cvmfs/default.local && \
     echo "CVMFS_USE_CDN='yes'" >> /etc/cvmfs/default.local && \
+    cvmfs_config setup || true && \
     dnf clean all
 
 COPY mount.sh /mount.sh
 
-CMD ["/bin/bash", "-c", "/mount.sh && /bin/bash"]
+ENTRYPOINT ["/bin/sh", "-c", "/mount.sh"]
+CMD ["/bin/bash"]

--- a/Docker/alma9/alma9-cvmfs/mount.sh
+++ b/Docker/alma9/alma9-cvmfs/mount.sh
@@ -1,7 +1,4 @@
+#!/bin/bash
 /usr/sbin/automount
 
-if [ -z "$1" ]; then
-    /bin/bash
-else
-    exec "$@"
-fi
+exec "$@"

--- a/Docker/alma9/alma9-cvmfs/mount.sh
+++ b/Docker/alma9/alma9-cvmfs/mount.sh
@@ -1,9 +1,7 @@
-if mount | grep -q cvmfs; then
-  echo "CVMFS already mounted"
-  echo "/mount.sh does not need to be run anymore"
-  exit 0
+/usr/sbin/automount
+
+if [ -z "$1" ]; then
+    /bin/bash
+else
+    exec "$@"
 fi
-set -e
-mount -t cvmfs cvmfs-config.cern.ch /cvmfs/cvmfs-config.cern.ch
-mount -t cvmfs sw.hsf.org /cvmfs/sw.hsf.org
-mount -t cvmfs sw-nightlies.hsf.org /cvmfs/sw-nightlies.hsf.org


### PR DESCRIPTION
This reduces the size of the alma9 images significantly. Using automount allows the image to be used in an easier way, without having to call the `mount.sh` script that was being used before.